### PR TITLE
Create Zebra sources path first

### DIFF
--- a/socket/jailbreak.h
+++ b/socket/jailbreak.h
@@ -19,6 +19,7 @@
 #define JB_FLAG_TWEAKS      0x00000002
 #define JB_FLAG_RESPRING    0x00000004
 
+#define ZEBRA_SOURCES_PATH "/var/mobile/Library/Application Support/xyz.willy.Zebra"
 #define ZEBRA_SOURCES_FILE "/var/mobile/Library/Application Support/xyz.willy.Zebra/sources.list"
 #define APT_TELESPHOREO_REPO "deb http://apt.saurik.com/ ios/1349.70 main"
 #define APT_BIGBOSS_REPO "deb http://apt.thebigboss.org/repofiles/cydia/ stable main"

--- a/socket/jailbreak.m
+++ b/socket/jailbreak.m
@@ -80,6 +80,9 @@ int remount_rootfs(void) {
 }
 
 int update_zebra_sources(void) {
+    mkdir(ZEBRA_SOURCES_PATH, 0755);
+    chown(ZEBRA_SOURCES_PATH, 501, 501);
+
     unlink(ZEBRA_SOURCES_FILE);
     FILE *file = fopen(ZEBRA_SOURCES_FILE, "w+");
     if (file == NULL) return -1;


### PR DESCRIPTION
Update the update_zebra_sources function to mkdir the sources path first before creating sources.plist. This fixes issue #11