### PR TITLE
fix: prevent cleanup() from corrupting user preferences

### DIFF
--- a/socket/jailbreak.m
+++ b/socket/jailbreak.m
@@ -20,9 +20,6 @@ void status(const char *str) {
 }
 
 void cleanup(void) {
-    [[NSUserDefaults standardUserDefaults] setObject:@"no" forKey:@"restrap"];
-    [[NSUserDefaults standardUserDefaults] synchronize];
-    
     flush_volume("/private/var");
     flush_volume("/");
     usleep(100000);

--- a/socket/supporting files/ViewController.m
+++ b/socket/supporting files/ViewController.m
@@ -110,6 +110,11 @@
         uint32_t flags = JB_FLAG_RESPRING;
         if ([[[NSUserDefaults standardUserDefaults] stringForKey:@"tweaks"] isEqual:@"yes"]) flags |= JB_FLAG_TWEAKS;
         if ([[[NSUserDefaults standardUserDefaults] stringForKey:@"restrap"] isEqual:@"yes"]) flags |= JB_FLAG_BOOTSTRAP;
+
+        // Reset restrap before UID escalation (NSUserDefaults breaks as root)
+        [[NSUserDefaults standardUserDefaults] setObject:@"no" forKey:@"restrap"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+
         int ret = run_jailbreak(flags);
         
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
cleanup() writes to NSUserDefaults after the process has escalated to root via set_permissions(). At that point, NSUserDefaults no longer operates on the app's sandboxed plist — it overwrites it with only `{restrap: "no"}`, losing the `tweaks` key.

On subsequent boots, `stringForKey:@"tweaks"` returns nil, `[nil isEqual:@"yes"]` is NO, and `load_daemons()` silently gets skipped. No Substrate injection, no LaunchDaemons, no rc.d scripts. The UI toggle still appears ON because the storyboard default is ON and `viewDidLoad` only explicitly sets it for `@"yes"` with no else clause.

The `legacy` branch avoided this by writing both keys back in cleanup():
```objc
[[NSUserDefaults standardUserDefaults] setObject:@"yes" forKey:@"tweaks"];
[[NSUserDefaults standardUserDefaults] setObject:@"no" forKey:@"restrap"];
```
When this was rewritten for `main`, the `tweaks` re-write was dropped, exposing the bug.

This PR moves the `restrap` reset to the ViewController, before `run_jailbreak()` — still running as mobile, NSUserDefaults works correctly, and flags have already been read.